### PR TITLE
Fix installation

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -74,6 +74,7 @@ set_permission() {
     chown -R $app:$app "/home/$app"
     chown -R $app:$app "/var/log/$app"
     chmod u=rwX,g=rX,o= "$final_path"
+    chmod u=rwx,g=rx,o= "$final_path/gitea"
     chmod u=rwX,g=rX,o= "/home/$app"
     chmod u=rwX,g=rX,o= "/var/log/$app"
 }

--- a/scripts/install
+++ b/scripts/install
@@ -78,11 +78,11 @@ config_gitea
 # Install gitea
 wget https://github.com/go-gitea/gitea/releases/download/v1.3.3/gitea-1.3.3-linux-amd64 -O $final_path/gitea
 
-# Start gitea for building mysql tables
-systemctl start "$app".service
-
 # Set permissions
 set_permission
+
+# Start gitea for building mysql tables
+systemctl start "$app".service
 
 # Wait till login_source mysql table is created
 while ! $(ynh_mysql_connect_as "$dbuser" "$dbpass" "$dbname"  <<< "SELECT * FROM login_source;" &>/dev/null)


### PR DESCRIPTION
Hi,
I just made a few commit to fix gitea installation.

- You were calling `config_gitea` before copying the app..ini file
- You were changing directory to $final_path so the file `../conf/login_source.sql` was not available anymore
- gitea was not executable so, the service did not start

gitea logs are empty so at the end `ynh_check_starting` do not detect service launching so we have to wait for 300s before the installation finish.
