### PR TITLE
README.md: Clarify ssh authentication with key

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,13 @@ PasswordAuthentication no
 UsePAM no
 ```
 
+For users that⁠—for [security reasons](https://yunohost.org/en/security#ssh-authentication-via-key)⁠—disabled the admin password and now perform SSH authentication via key, keep `UsePAM yes` and add `AllowUsers gitea`:
+
+```bash
+UsePAM yes
+AllowUsers gitea
+```
+
 You also need to add your public key to your Gitea profile.
 
 If you use ssh on another port than 22, you need to add theses lines to your ssh config in `~/.ssh/config`:


### PR DESCRIPTION
Only managed to successfully `ssh -T gitea@[...]` with these two changes. 

Without them, I would just get:

```
gitea@[...]: Permission denied (publickey).
fatal: Could not read from remote repository.
```

Solved it thanks to this comment https://framagit.org/YunoHost-Apps/gitea_ynh/-/issues/18#note_707336