### PR TITLE
The proposed changes for sshd_config seems to be unrelated to Gitea

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,14 +49,10 @@ Additional informations
 
 ### Notes on SSH usage
 
-If you want to use Gitea with ssh and be able to pull/push with you ssh key, your ssh daemon must be properly configured to use private/public keys. Here is a sample configuration of `/etc/ssh/sshd_config` that works with Gitea:
+If you want to use Gitea with ssh and be able to pull/push with you ssh key, you will need to add the `gitea` user in the ssh permission with this command:
 
-```bash
-PubkeyAuthentication yes
-AuthorizedKeysFile /home/%u/.ssh/authorized_keys
-ChallengeResponseAuthentication no
-PasswordAuthentication no
-UsePAM no
+```
+sudo adduser gitea ssh.app
 ```
 
 You also need to add your public key to your Gitea profile.
@@ -68,11 +64,6 @@ Host domain.tld
     port 2222 # change this with the port you use
 ```
 
-You will also need to add the `gitea` user in the ssh permission with this command:
-
-```
-sudo adduser gitea ssh.app
-```
 
 ### Architecture
 


### PR DESCRIPTION
These are for like 4 years ago, dunno what changed in the upstream sshd default options but: 

- `PubkeyAuthentication` is `yes` by default, no need to specify it
- `AuthorizedKeysFile` is already `.ssh/authorized_keys` by default, relative to the user's home
- `ChallengeResponseAuthentication`'s default is yes, but this seems to have no relation with being able to authenticate with ssh keys
- `PasswordAuthentication` should have no relation with being able to authenticate with ssh keys and is likely to break login for admin and other accounts if the admin did not add proper keys for other accounts ...
- `UsePAM no` **is likely to fuck a lot of things up**

If any of these turns out to actually be useful, they should be wrapped in a `Match User gitea` to not interfere with the other accounts