### PR TITLE
Implementing auto update

### DIFF
--- a/.github/workflows/updater.sh
+++ b/.github/workflows/updater.sh
@@ -48,7 +48,7 @@ assets=($(curl --silent "https://api.github.com/repos/$repo/releases" | jq -r '[
 # Sometimes the release name starts with a "v", so let's filter it out.
 # You may need more tweaks here if the upstream repository has different naming conventions. 
 if [[ ${version:0:1} == "v" || ${version:0:1} == "V" ]]; then
-    version=${version:1}
+  version=${version:1}
 fi
 
 # Setting up the environment variables
@@ -60,16 +60,16 @@ echo "PROCEED=false" >> "$GITHUB_ENV"
 
 # Proceed only if the retrieved version is greater than the current one
 if ! dpkg --compare-versions "$current_version" "lt" "$version" ; then
-    echo "::warning ::No new version available"
-    exit 0
+  echo "::warning ::No new version available"
+  exit 0
 # Proceed only if the retrieved version is not a release candidate
 elif [[ "$version" == *"rc"* ]] ; then
-    echo "::warning ::No new stable version available (there is a release candidate)"
-    exit 0
+  echo "::warning ::No new stable version available (there is a release candidate)"
+  exit 0
 # Proceed only if a PR for this new version does not already exist
 elif git ls-remote -q --exit-code --heads https://github.com/"$GITHUB_REPOSITORY".git ci-auto-update-v"$version" ; then
-    echo "::warning ::A branch already exists for this update"
-    exit 0
+  echo "::warning ::A branch already exists for this update"
+  exit 0
 fi
 
 # Each release can hold multiple assets (e.g. binaries for different architectures, source code, etc.)
@@ -140,17 +140,15 @@ esac
 
 # If $src is not empty, let's process the asset
 if [ -n "$src" ]; then
+  # Get checksum
+  filename=${asset_url##*/}
+  checksum=$(< "$tempdir/$filename.sha256" awk '{print $1;}')
 
-# Get checksum
-filename=${asset_url##*/}
-checksum=$(< "$tempdir/$filename.sha256" awk '{print $1;}')
+  path="conf/source/$src.src"
 
-path="conf/source/$src.src"
-
-update_source_file
-
+  update_source_file
 else
-echo "... asset ignored"
+  echo "... asset ignored"
 fi
 
 done

--- a/.github/workflows/updater.sh
+++ b/.github/workflows/updater.sh
@@ -9,8 +9,12 @@
 # Since each app is different, maintainers can adapt its contents so as to perform
 # automatic actions when a new upstream release is detected.
 
-# Remove this exit command when you are ready to run this Action
-# exit 1
+update_source_file() {
+# Rewrite source file
+sed -i "s@SOURCE_URL=.*@SOURCE_URL=$asset_url@" "$path"
+sed -i "s@SOURCE_SUM=.*@SOURCE_SUM=$checksum@" "$path"
+echo "... $path"
+}
 
 #=================================================
 # FETCHING LATEST RELEASE AND ITS ASSETS
@@ -84,6 +88,7 @@ esac
 
 done
 
+echo "Checksums acquired."
 
 echo "Second loop for processing source files..."
 
@@ -123,15 +128,16 @@ if [ -n "$src" ]; then
 filename=${asset_url##*/}
 checksum=$(< "$tempdir/$filename.sha256" awk '{print $1;}')
 
-# Rewrite source file
-cat <<EOT > "conf/source/$src.src"
-SOURCE_URL=$asset_url
-SOURCE_SUM=$checksum
-SOURCE_SUM_PRG=sha256sum
-SOURCE_FILENAME=gitea
-SOURCE_EXTRACT=false
-EOT
-echo "... conf/source/$src.src updated"
+path="conf/source/$src.src"
+
+# patching the armv7 file with the armv6 bin version
+if [ "$src" = "arm" ]; then
+  update_source_file
+  path="conf/source/armv7.src"
+  update_source_file
+else
+  update_source_file
+fi
 
 else
 echo "... asset ignored"
@@ -139,9 +145,49 @@ fi
 
 done
 
+echo "Upgrade done."
 
-# Delete temporary directory
-rm -rf "$tempdir"
+
+last_main_version="${current_version%.*}"
+main_version="${version%.*}"
+
+if [ "$last_main_version" != "$main_version" ]; then
+
+  echo "Minor or major version number increased, creating migration stuff:"
+
+  for i in arm arm64 armv7 i386 x86-64
+  do
+
+    path="conf/source/${i}_${last_main_version}.src"
+    cp conf/source/"$i".src "$path"
+
+    # retrieve the last minor release of the main version
+    last_main_version_full=$(curl --silent "https://api.github.com/repos/$repo/releases" | jq -r '.[] | select( .prerelease != true ) | .tag_name' | sort -V | grep "$last_main_version" | tail -1 | cut -c2-)
+
+    # set the checksum file link
+    if [ "$i" = "arm" ]; then
+      asset_url="https://github.com/$repo/releases/download/v$last_main_version_full/gitea-$last_main_version_full-linux-arm-6"
+    elif [ "$i" = "armv7" ]; then
+      asset_url="https://github.com/$repo/releases/download/v$last_main_version_full/gitea-$last_main_version_full-linux-arm-6"
+    elif [ "$i" = "arm64" ]; then
+      asset_url="https://github.com/$repo/releases/download/v$last_main_version_full/gitea-$last_main_version_full-linux-arm64"
+    elif [ "$i" = "i386" ]; then
+      asset_url="https://github.com/$repo/releases/download/v$last_main_version_full/gitea-$last_main_version_full-linux-386"
+    elif [ "$i" = "x86-64" ]; then
+      asset_url="https://github.com/$repo/releases/download/v$last_main_version_full/gitea-$last_main_version_full-linux-amd64"
+    fi
+
+    # downloading the checksum
+    echo "Downloading checksum file at" "$asset_url.sha256"
+    checksum=$(curl --silent -4 -L "$asset_url.sha256" | awk '{print $1;}')
+
+    update_source_file
+
+  done
+
+  echo "Creation of source files for migration completed"
+
+fi
 
 
 #=================================================
@@ -151,14 +197,38 @@ rm -rf "$tempdir"
 # Any action on the app's source code can be done.
 # The GitHub Action workflow takes care of committing all changes after this script ends.
 
+#         WE need to add this
+#         "1.7."* )
+#             ynh_setup_source $final_path source/${architecture}_1.8
+#             restart_gitea
+#         ;&
+#         esac
+
+if [ "$last_main_version" != "$main_version" ]; then
+
+  echo "Creating the migration steps in the upgrade file"
+
+  last_last_version=$(grep 'ynh_setup_source $final_path source/${architecture}_' scripts/upgrade | tail -n1 | grep -Eo '[[:alnum:]]+\.[[:alnum:]]+$')
+  perl -0777 -pe "s@restart_gitea\n;&\nesac@restart_gitea\n;&\n\"${last_last_version}."'"* )\n    ynh_setup_source \$final_path source/\${architecture}_'"${main_version}\n    restart_gitea\n;&\nesac@" scripts/upgrade > "$tempdir"/upgrade
+  mv "$tempdir"/upgrade scripts/upgrade
+
+  echo "Migration stuff is done."
+
+fi
+
 #=================================================
 # GENERIC FINALIZATION
 #=================================================
+
+# Delete temporary directory
+rm -rf "$tempdir"
 
 # Replace new version in manifest
 echo "$(jq -s --indent 4 ".[] | .version = \"$version~ynh1\"" manifest.json)" > manifest.json
 
 # No need to update the README, yunohost-bot takes care of it
+
+echo "End of script."
 
 # The Action will proceed only if the PROCEED environment variable is set to true
 echo "PROCEED=true" >> "$GITHUB_ENV"

--- a/.github/workflows/updater.sh
+++ b/.github/workflows/updater.sh
@@ -160,7 +160,7 @@ echo "Upgrade done."
 
 # retrieving the actual version in the config file
 patch_version="$(grep -Eo 'SOURCE_URL=.*' conf/source/armv7.src | cut -d'v' -f2 | cut -d'/' -f1)"
-if [ "$current_version" != "$patch_version" ]; then
+if [ "$version" != "$patch_version" ]; then
   patch_source_file "conf/source/arm.src" "conf/source/armv7.src"
 fi
 
@@ -204,7 +204,7 @@ if [ "$last_main_version" != "$main_version" ]; then
 
   # retrieving the actual version in the config file
   patch_version="$(grep -Eo 'SOURCE_URL=.*' "conf/source/armv7_${last_main_version}.src" | cut -d'v' -f2 | cut -d'/' -f1)"
-  if [ "$current_version" != "$patch_version" ]; then
+  if [ "$version" != "$patch_version" ]; then
     patch_source_file "conf/source/arm_${last_main_version}.src" "conf/source/armv7_${last_main_version}.src"
   fi
 

--- a/.github/workflows/updater.sh
+++ b/.github/workflows/updater.sh
@@ -1,0 +1,167 @@
+#!/bin/bash
+
+#=================================================
+# PACKAGE UPDATING HELPER
+#=================================================
+
+# This script is meant to be run by GitHub Actions
+# The YunoHost-Apps organisation offers a template Action to run this script periodically
+# Since each app is different, maintainers can adapt its contents so as to perform
+# automatic actions when a new upstream release is detected.
+
+# Remove this exit command when you are ready to run this Action
+# exit 1
+
+#=================================================
+# FETCHING LATEST RELEASE AND ITS ASSETS
+#=================================================
+
+# Fetching information
+current_version=$(jq -j '.version|split("~")[0]' manifest.json)
+repo=$(jq -j '.upstream.code|split("https://github.com/")[1]' manifest.json)
+# Some jq magic is needed, because the latest upstream release is not always the latest version (e.g. security patches for older versions)
+version=$(curl --silent "https://api.github.com/repos/$repo/releases" | jq -r '.[] | select( .prerelease != true ) | .tag_name' | sort -V | tail -1)
+assets=($(curl --silent "https://api.github.com/repos/$repo/releases" | jq -r '[ .[] | select(.tag_name=="'"$version"'").assets[].browser_download_url ] | join(" ") | @sh' | tr -d "'"))
+
+# Later down the script, we assume the version has only digits and dots
+# Sometimes the release name starts with a "v", so let's filter it out.
+# You may need more tweaks here if the upstream repository has different naming conventions. 
+if [[ ${version:0:1} == "v" || ${version:0:1} == "V" ]]; then
+    version=${version:1}
+fi
+
+# Setting up the environment variables
+echo "Current version: $current_version"
+echo "Latest release from upstream: $version"
+{ echo "VERSION=$version"; echo "REPO=$repo"; } >> "$GITHUB_ENV"
+# For the time being, let's assume the script will fail
+echo "PROCEED=false" >> "$GITHUB_ENV"
+
+# Proceed only if the retrieved version is greater than the current one
+if ! dpkg --compare-versions "$current_version" "lt" "$version" ; then
+    echo "::warning ::No new stable version available"
+    exit 0
+# Proceed only if the retrieved version is not a release candidate
+elif [[ "$version" == *"rc"* ]] ; then
+    echo "::warning ::No new stable version available (there is a release candidate)"
+    exit 0
+# Proceed only if a PR for this new version does not already exist
+elif git ls-remote -q --exit-code --heads https://github.com/"$GITHUB_REPOSITORY".git ci-auto-update-v"$version" ; then
+    echo "::warning ::A branch already exists for this update"
+    exit 0
+fi
+
+# Each release can hold multiple assets (e.g. binaries for different architectures, source code, etc.)
+echo "${#assets[@]} available asset(s)"
+
+#=================================================
+# UPDATE SOURCE FILES
+#=================================================
+
+# Here we use the $assets variable to get the resources published in the upstream release.
+# Here is an example for Grav, it has to be adapted in accordance with how the upstream releases look like.
+
+# Create the temporary directory
+tempdir="$(mktemp -d)"
+
+# Let's loop over the array of assets URLs
+for asset_url in "${assets[@]}"; do
+
+echo "First loop for processing checksums..."
+echo "Handling asset at $asset_url"
+
+case $asset_url in
+  *".sha256")
+    checksum=1
+    ;;
+  *)
+    checksum=0
+    ;;
+esac
+
+if checksum; then
+  # Download checksums
+  echo "Downloading checksum file at" "${asset_url##*/}"
+  curl --silent -4 -L "${asset_url##*/}" -o "$tempdir/checksums/"
+fi
+
+done
+
+
+# Let's loop over the array of assets URLs
+for asset_url in "${assets[@]}"; do
+
+echo "Second loop for processing source files..."
+echo "Handling asset at $asset_url"
+
+# Assign the asset to a source file in conf/ directory
+# Here we base the source file name upon a unique keyword in the assets url (admin vs. update)
+# Leave $src empty to ignore the asset
+case $asset_url in
+  *"linux-386")
+    src="i386"
+    ;;
+  *"linux-amd64")
+    src="x86-64"
+    ;;
+  *"linux-arm64")
+    src="arm64"
+    ;;
+  *"linux-arm-6")
+    src="arm"
+    ;;
+  *"linux-arm-7")
+    src="armv7"
+    ;;
+  *)
+    src=""
+    ;;
+esac
+
+# If $src is not empty, let's process the asset
+if [ -n "$src" ]; then
+
+# Get checksum
+filename=${asset_url##*/}
+checksum=$(< "$tempdir/checksums/$filename.sha256" awk '{print $1;}')
+
+# Rewrite source file
+cat <<EOT > "conf/$src.src"
+SOURCE_URL=$asset_url
+SOURCE_SUM=$checksum
+SOURCE_SUM_PRG=sha256sum
+SOURCE_FILENAME=gitea
+SOURCE_EXTRACT=false
+EOT
+echo "... conf/$src.src updated"
+
+else
+echo "... asset ignored"
+fi
+
+done
+
+
+# Delete temporary directory
+rm -rf "$tempdir"
+
+
+#=================================================
+# SPECIFIC UPDATE STEPS
+#=================================================
+
+# Any action on the app's source code can be done.
+# The GitHub Action workflow takes care of committing all changes after this script ends.
+
+#=================================================
+# GENERIC FINALIZATION
+#=================================================
+
+# Replace new version in manifest
+echo "$(jq -s --indent 4 ".[] | .version = \"$version~ynh1\"" manifest.json)" > manifest.json
+
+# No need to update the README, yunohost-bot takes care of it
+
+# The Action will proceed only if the PROCEED environment variable is set to true
+echo "PROCEED=false" >> "$GITHUB_ENV"
+exit 0

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Fetch the source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run the updater script
@@ -33,7 +33,7 @@ jobs:
       - name: Create Pull Request
         id: cpr
         if: ${{ env.PROCEED == 'true' }}
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: Update to version ${{ env.VERSION }}

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -1,0 +1,50 @@
+# This workflow allows GitHub Actions to automagically update your app whenever a new upstream release is detected.
+# You need to enable Actions in your repository settings, and fetch this Action from the YunoHost-Apps organization.
+# This file should be enough by itself, but feel free to tune it to your needs.
+# It calls updater.sh, which is where you should put the app-specific update steps.
+name: Check for new upstream releases
+on:
+  # Allow to manually trigger the workflow
+  workflow_dispatch:
+  # Run it every day at 6:00 UTC
+  schedule:
+    - cron:  '0 6 * * *'
+jobs:
+  updater:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch the source code
+        uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run the updater script
+        id: run_updater
+        run: |
+          # Setting up Git user
+          git config --global user.name 'yunohost-bot'
+          git config --global user.email 'yunohost-bot@users.noreply.github.com'
+          # Run the updater script
+          /bin/bash .github/workflows/updater.sh
+      - name: Commit changes
+        id: commit
+        if: ${{ env.PROCEED == 'true' }}
+        run: |
+          git commit -am "Upgrade to v$VERSION"
+      - name: Create Pull Request
+        id: cpr
+        if: ${{ env.PROCEED == 'true' }}
+        uses: peter-evans/create-pull-request@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: Update to version ${{ env.VERSION }}
+          committer: 'yunohost-bot <yunohost-bot@users.noreply.github.com>'
+          author: 'yunohost-bot <yunohost-bot@users.noreply.github.com>'
+          signoff: false
+          base: testing
+          branch: ci-auto-update-v${{ env.VERSION }}
+          delete-branch: true
+          title: 'Upgrade to version ${{ env.VERSION }}'
+          body: |
+            Upgrade to v${{ env.VERSION }}
+            Changelog: https://github.com/${{ env.REPO }}/releases/tag/v${{ env.VERSION }}
+          draft: false

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -234,10 +234,6 @@ case $upstream_version in
     restart_gitea
 ;&
 "1.16."* )
-    ynh_setup_source $final_path source/${architecture}_1.16
-    restart_gitea
-;&
-"1.16."* )
     ynh_setup_source $final_path source/${architecture}_1.17
     restart_gitea
 ;&


### PR DESCRIPTION
gitea updates are often slow to arrive on ynh
so I thought I'd implement auto update to help you

I have two questions:
- why keep all past versions of the sources, and not overwrite the same file at each update?
- are the armv7 builds still really broken?
```
# The armv7 build is brocken
# See : https://github.com/go-gitea/gitea/issues/6700
# Use temporary the armv6 binary
```
https://github.com/YunoHost-Apps/gitea_ynh/blob/master/conf/source/armv7.src#L1L3

at the moment the script **doesn't** take these 2 things into account because they are maybe not relevant anymore
I'll make the appropriate changes if it turns out that it was necessary

the script ignores the release candidates, by the way

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)
