### PR TITLE
Activate gitea actions

### DIFF
--- a/conf/app.ini
+++ b/conf/app.ini
@@ -3,6 +3,9 @@ APP_NAME = Gitea
 RUN_USER = __APP__
 RUN_MODE = prod
 
+[actions]
+ENABLED = true
+
 [database]
 DB_TYPE = mysql
 HOST = 127.0.0.1:3306


### PR DESCRIPTION
## Problem

- Gitea actions has released its actions in 1.19.0 but is not activated by default. See https://blog.gitea.io/2023/03/gitea-1.19.0-is-released/

## Solution

- Modify app.ini according to https://blog.gitea.io/2022/12/feature-preview-gitea-actions/
- The next step I intend to do is to package [act_runner](https://gitea.com/gitea/act_runner) for yunohost so it can be installed and linked it to an existing gitea instance

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)

Edit : I may have been a bit too fast as even if it has been announced in 1.19.0 it is still in preview. I have played a bit with it on my own instance and haven't seen any kind of instability.
If we don't want to activate the feature by default, we could always ask at the install step. Or explain in the README how to active it. Either way is fine by me.