### PR TITLE
Replacements for access, router and xorm log in app.ini

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ If you want to use the Git command (like `git clone`, `git pull`, `git push`), y
 * Official app website: <https://gitea.io/>
 * Official admin documentation: <https://docs.gitea.io/>
 * Upstream app code repository: <https://github.com/go-gitea/gitea>
+* YunoHost Store: <https://apps.yunohost.org/app/gitea>
 * Report a bug: <https://github.com/YunoHost-Apps/gitea_ynh/issues>
 
 ## Developer info

--- a/README_fr.md
+++ b/README_fr.md
@@ -110,6 +110,7 @@ If you want to use the Git command (like `git clone`, `git pull`, `git push`), y
 * Site officiel de l’app : <https://gitea.io/>
 * Documentation officielle de l’admin : <https://docs.gitea.io/>
 * Dépôt de code officiel de l’app : <https://github.com/go-gitea/gitea>
+* YunoHost Store: <https://apps.yunohost.org/app/gitea>
 * Signaler un bug : <https://github.com/YunoHost-Apps/gitea_ynh/issues>
 
 ## Informations pour les développeurs

--- a/conf/app.ini
+++ b/conf/app.ini
@@ -62,18 +62,23 @@ PROVIDER = memory
 MODE      = file
 LEVEL     = Info
 ROOT_PATH = /var/log/__APP__
+logger.access.MODE = 
+logger.router.MODE = router
+logger.xorm.MODE = xorm
 
 REDIRECT_MACARON_LOG= true
 MACARON             = file
 
-ROUTER_LOG_LEVEL    = Warn
-ROUTER              = file
+[log.file]
+FILE_NAME = gitea.log
 
-ENABLE_ACCESS_LOG   = Warn
-ACCESS              = file
+[log.router]
+FILE_NAME = router.log
+LEVEL = Warn
 
-ENABLE_XORM_LOG     = Warn
-XORM                = file
+[log.xorm]
+FILE_NAME = xorm.log
+LEVEL = Warn
 
 [security]
 INSTALL_LOCK = true


### PR DESCRIPTION
## Problem

This log entry came up in my Gitea instance.
```
Deprecated config option `[log]` `ACCESS` present. Use `[log]` `logger.access.MODE` instead. This fallback will be/has been removed in 1.21 (and 5 more)
```
![image](https://github.com/YunoHost-Apps/gitea_ynh/assets/19874562/1224ec2c-745d-4b9d-a4ff-c735c2036bfd)

## Solution

Replace deprecated log entries in `app.ini` using the options from the official docs: https://docs.gitea.com/administration/logging-config. I replaced them for `ACCESS`, `ROUTER` and `XORM`. However, I have no idea what `MACARON` is. Is that still needed? Might be deprecated too...

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
