### PR TITLE
Replace SKIP_VERIFY with FORCE_TRUST_SERVER_CERT in app.ini

### DIFF
--- a/conf/app.ini
+++ b/conf/app.ini
@@ -38,7 +38,7 @@ ENABLED = true
 SMTP_ADDR = 127.0.0.1
 SMTP_PORT = 25
 FROM = "Gitea" <gitea-noreply@__DOMAIN__>
-SKIP_VERIFY = true
+FORCE_TRUST_SERVER_CERT = true
 
 [service]
 REGISTER_EMAIL_CONFIRM = false


### PR DESCRIPTION
## Problem

After upgrading to Gitea 1.21.0 there was another deprecation notice on Site Administration page.
```
Deprecated config option `[mailer]` `SKIP_VERIFY` present. Use `[mailer]` `FORCE_TRUST_SERVER_CERT` instead. This fallback will be/has been removed in v1.19.0
```
![image](https://github.com/YunoHost-Apps/gitea_ynh/assets/19874562/16dcfd2f-f27b-4b72-be84-d4f7674367c9)

## Solution

As written here https://blog.gitea.com/release-of-1.18.0/ `SKIP_VERIFY` has been replaced with `FORCE_TRUST_SERVER_CERT`. So, I replaced it in `app.ini`. 

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
