### PR TITLE
[autopatch] TEST BEFORE MERGE ynh_setup_source --full_replace=1

### DIFF
--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -54,7 +54,7 @@ if [ ~"$app" != "$data_dir" ]; then
 fi
 
 # Ensure secrets are defined
-ynh_setup_source --dest_dir="$install_dir" --source_id=main
+ynh_setup_source --dest_dir="$install_dir" --source_id=main --full_replace=1
 
 #=================================================
 # MIGRATION STEP 2 (Set undefined Vars)

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -54,7 +54,7 @@ if [ ~"$app" != "$data_dir" ]; then
 fi
 
 # Ensure secrets are defined
-ynh_setup_source --dest_dir="$install_dir" --source_id=main --full_replace=1
+ynh_setup_source --dest_dir="$install_dir" --source_id=main --full_replace=1 --keep=custom
 
 #=================================================
 # MIGRATION STEP 2 (Set undefined Vars)


### PR DESCRIPTION
This is an automatic PR

This is an ***automated*** patch to potentially fix a bug in the upgrade script.

`ynh_setup_source` doesn't overwrite the destination directory, but rather extracts the source in the existing directory.

This might lead to weird cases where legacy source files aren't deleted.

The command has an argument `--full_replace=1` that fixes this behaviour.

BE CAREFUL because this change might lead to data losses! You should check that all the patches calls to `ynh_setup_source`
_do exactly what you expect to do_ and don't **delete user data**.

If you want exclude some files from being overwritten/deleted, use the `--keep` argument, just like that:

```bash
ynh_setup_source --dest_dir="$install_dir" --full_replace=1 --keep="config/config.yaml"
```