### PR TITLE
Remove i386 from supported architectures.

### DIFF
--- a/ALL_README.md
+++ b/ALL_README.md
@@ -7,5 +7,6 @@
 - [Le o README en galego](README_gl.md)
 - [Baca README dalam bahasa bahasa Indonesia](README_id.md)
 - [Lees de README in het Nederlands](README_nl.md)
+- [Przeczytaj README w języku polski](README_pl.md)
 - [Прочитать README на русский](README_ru.md)
 - [阅读中文（简体）的 README](README_zh_Hans.md)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@ It shall NOT be edited by hand.
 
 # Gitea for YunoHost
 
-[![Integration level](https://dash.yunohost.org/integration/gitea.svg)](https://ci-apps.yunohost.org/ci/apps/gitea/) ![Working status](https://ci-apps.yunohost.org/ci/badges/gitea.status.svg) ![Maintenance status](https://ci-apps.yunohost.org/ci/badges/gitea.maintain.svg)
+[![Integration level](https://apps.yunohost.org/badge/integration/gitea)](https://ci-apps.yunohost.org/ci/apps/gitea/)
+![Working status](https://apps.yunohost.org/badge/state/gitea)
+![Maintenance status](https://apps.yunohost.org/badge/maintained/gitea)
 
 [![Install Gitea with YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=gitea)
 

--- a/README_es.md
+++ b/README_es.md
@@ -5,7 +5,9 @@ No se debe editar a mano.
 
 # Gitea para Yunohost
 
-[![Nivel de integración](https://dash.yunohost.org/integration/gitea.svg)](https://ci-apps.yunohost.org/ci/apps/gitea/) ![Estado funcional](https://ci-apps.yunohost.org/ci/badges/gitea.status.svg) ![Estado En Mantención](https://ci-apps.yunohost.org/ci/badges/gitea.maintain.svg)
+[![Nivel de integración](https://apps.yunohost.org/badge/integration/gitea)](https://ci-apps.yunohost.org/ci/apps/gitea/)
+![Estado funcional](https://apps.yunohost.org/badge/state/gitea)
+![Estado En Mantención](https://apps.yunohost.org/badge/maintained/gitea)
 
 [![Instalar Gitea con Yunhost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=gitea)
 

--- a/README_eu.md
+++ b/README_eu.md
@@ -5,7 +5,9 @@ EZ editatu eskuz.
 
 # Gitea YunoHost-erako
 
-[![Integrazio maila](https://dash.yunohost.org/integration/gitea.svg)](https://ci-apps.yunohost.org/ci/apps/gitea/) ![Funtzionamendu egoera](https://ci-apps.yunohost.org/ci/badges/gitea.status.svg) ![Mantentze egoera](https://ci-apps.yunohost.org/ci/badges/gitea.maintain.svg)
+[![Integrazio maila](https://apps.yunohost.org/badge/integration/gitea)](https://ci-apps.yunohost.org/ci/apps/gitea/)
+![Funtzionamendu egoera](https://apps.yunohost.org/badge/state/gitea)
+![Mantentze egoera](https://apps.yunohost.org/badge/maintained/gitea)
 
 [![Instalatu Gitea YunoHost-ekin](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=gitea)
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -5,7 +5,9 @@ Il NE doit PAS être modifié à la main.
 
 # Gitea pour YunoHost
 
-[![Niveau d’intégration](https://dash.yunohost.org/integration/gitea.svg)](https://ci-apps.yunohost.org/ci/apps/gitea/) ![Statut du fonctionnement](https://ci-apps.yunohost.org/ci/badges/gitea.status.svg) ![Statut de maintenance](https://ci-apps.yunohost.org/ci/badges/gitea.maintain.svg)
+[![Niveau d’intégration](https://apps.yunohost.org/badge/integration/gitea)](https://ci-apps.yunohost.org/ci/apps/gitea/)
+![Statut du fonctionnement](https://apps.yunohost.org/badge/state/gitea)
+![Statut de maintenance](https://apps.yunohost.org/badge/maintained/gitea)
 
 [![Installer Gitea avec YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=gitea)
 

--- a/README_gl.md
+++ b/README_gl.md
@@ -5,7 +5,9 @@ NON debe editarse manualmente.
 
 # Gitea para YunoHost
 
-[![Nivel de integración](https://dash.yunohost.org/integration/gitea.svg)](https://ci-apps.yunohost.org/ci/apps/gitea/) ![Estado de funcionamento](https://ci-apps.yunohost.org/ci/badges/gitea.status.svg) ![Estado de mantemento](https://ci-apps.yunohost.org/ci/badges/gitea.maintain.svg)
+[![Nivel de integración](https://apps.yunohost.org/badge/integration/gitea)](https://ci-apps.yunohost.org/ci/apps/gitea/)
+![Estado de funcionamento](https://apps.yunohost.org/badge/state/gitea)
+![Estado de mantemento](https://apps.yunohost.org/badge/maintained/gitea)
 
 [![Instalar Gitea con YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=gitea)
 

--- a/README_id.md
+++ b/README_id.md
@@ -5,7 +5,9 @@ Ini TIDAK boleh diedit dengan tangan.
 
 # Gitea untuk YunoHost
 
-[![Tingkat integrasi](https://dash.yunohost.org/integration/gitea.svg)](https://ci-apps.yunohost.org/ci/apps/gitea/) ![Status kerja](https://ci-apps.yunohost.org/ci/badges/gitea.status.svg) ![Status pemeliharaan](https://ci-apps.yunohost.org/ci/badges/gitea.maintain.svg)
+[![Tingkat integrasi](https://apps.yunohost.org/badge/integration/gitea)](https://ci-apps.yunohost.org/ci/apps/gitea/)
+![Status kerja](https://apps.yunohost.org/badge/state/gitea)
+![Status pemeliharaan](https://apps.yunohost.org/badge/maintained/gitea)
 
 [![Pasang Gitea dengan YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=gitea)
 

--- a/README_nl.md
+++ b/README_nl.md
@@ -5,7 +5,9 @@ Hij mag NIET handmatig aangepast worden.
 
 # Gitea voor Yunohost
 
-[![Integratieniveau](https://dash.yunohost.org/integration/gitea.svg)](https://ci-apps.yunohost.org/ci/apps/gitea/) ![Mate van functioneren](https://ci-apps.yunohost.org/ci/badges/gitea.status.svg) ![Onderhoudsstatus](https://ci-apps.yunohost.org/ci/badges/gitea.maintain.svg)
+[![Integratieniveau](https://apps.yunohost.org/badge/integration/gitea)](https://ci-apps.yunohost.org/ci/apps/gitea/)
+![Mate van functioneren](https://apps.yunohost.org/badge/state/gitea)
+![Onderhoudsstatus](https://apps.yunohost.org/badge/maintained/gitea)
 
 [![Gitea met Yunohost installeren](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=gitea)
 

--- a/README_pl.md
+++ b/README_pl.md
@@ -1,0 +1,50 @@
+<!--
+To README zostało automatycznie wygenerowane przez <https://github.com/YunoHost/apps/tree/master/tools/readme_generator>
+Nie powinno być ono edytowane ręcznie.
+-->
+
+# Gitea dla YunoHost
+
+[![Poziom integracji](https://apps.yunohost.org/badge/integration/gitea)](https://ci-apps.yunohost.org/ci/apps/gitea/)
+![Status działania](https://apps.yunohost.org/badge/state/gitea)
+![Status utrzymania](https://apps.yunohost.org/badge/maintained/gitea)
+
+[![Zainstaluj Gitea z YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=gitea)
+
+*[Przeczytaj plik README w innym języku.](./ALL_README.md)*
+
+> *Ta aplikacja pozwala na szybką i prostą instalację Gitea na serwerze YunoHost.*  
+> *Jeżeli nie masz YunoHost zapoznaj się z [poradnikiem](https://yunohost.org/install) instalacji.*
+
+## Przegląd
+
+Gitea is a fork of Gogs a self-hosted Git service written in Go. Alternative to GitHub.
+
+
+**Dostarczona wersja:** 1.22.3~ynh1
+
+## Zrzuty ekranu
+
+![Zrzut ekranu z Gitea](./doc/screenshots/screenshot.png)
+
+## Dokumentacja i zasoby
+
+- Oficjalna strona aplikacji: <https://gitea.io/>
+- Oficjalna dokumentacja dla administratora: <https://docs.gitea.io/>
+- Repozytorium z kodem źródłowym: <https://github.com/go-gitea/gitea>
+- Sklep YunoHost: <https://apps.yunohost.org/app/gitea>
+- Zgłaszanie błędów: <https://github.com/YunoHost-Apps/gitea_ynh/issues>
+
+## Informacje od twórców
+
+Wyślij swój pull request do [gałęzi `testing`](https://github.com/YunoHost-Apps/gitea_ynh/tree/testing).
+
+Aby wypróbować gałąź `testing` postępuj zgodnie z instrukcjami:
+
+```bash
+sudo yunohost app install https://github.com/YunoHost-Apps/gitea_ynh/tree/testing --debug
+lub
+sudo yunohost app upgrade gitea -u https://github.com/YunoHost-Apps/gitea_ynh/tree/testing --debug
+```
+
+**Więcej informacji o tworzeniu paczek aplikacji:** <https://yunohost.org/packaging_apps>

--- a/README_ru.md
+++ b/README_ru.md
@@ -5,7 +5,9 @@
 
 # Gitea для YunoHost
 
-[![Уровень интеграции](https://dash.yunohost.org/integration/gitea.svg)](https://ci-apps.yunohost.org/ci/apps/gitea/) ![Состояние работы](https://ci-apps.yunohost.org/ci/badges/gitea.status.svg) ![Состояние сопровождения](https://ci-apps.yunohost.org/ci/badges/gitea.maintain.svg)
+[![Уровень интеграции](https://apps.yunohost.org/badge/integration/gitea)](https://ci-apps.yunohost.org/ci/apps/gitea/)
+![Состояние работы](https://apps.yunohost.org/badge/state/gitea)
+![Состояние сопровождения](https://apps.yunohost.org/badge/maintained/gitea)
 
 [![Установите Gitea с YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=gitea)
 

--- a/README_zh_Hans.md
+++ b/README_zh_Hans.md
@@ -5,7 +5,9 @@
 
 # YunoHost 上的 Gitea
 
-[![集成程度](https://dash.yunohost.org/integration/gitea.svg)](https://ci-apps.yunohost.org/ci/apps/gitea/) ![工作状态](https://ci-apps.yunohost.org/ci/badges/gitea.status.svg) ![维护状态](https://ci-apps.yunohost.org/ci/badges/gitea.maintain.svg)
+[![集成程度](https://apps.yunohost.org/badge/integration/gitea)](https://ci-apps.yunohost.org/ci/apps/gitea/)
+![工作状态](https://apps.yunohost.org/badge/state/gitea)
+![维护状态](https://apps.yunohost.org/badge/maintained/gitea)
 
 [![使用 YunoHost 安装 Gitea](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=gitea)
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -27,7 +27,6 @@ yunohost = ">= 11.2.30"
 helpers_version = "2.1"
 architectures = [
     "amd64",
-    "i386",
     "armhf",
     "arm64"
 ]
@@ -72,15 +71,12 @@ ram.runtime = "100M"
     armhf.sha256 = "28c92642acd87544b9bff9b1c333325abd3993659839f27d438a7ba9ae85ff6e"
     arm64.url = "https://github.com/go-gitea/gitea/releases/download/v1.22.3/gitea-1.22.3-linux-arm64"
     arm64.sha256 = "0d957ca51317be75788a7d286193fb550463c432518fb4b2dd05c19df3910b22"
-    i386.url = "https://github.com/go-gitea/gitea/releases/download/v1.22.3/gitea-1.22.3-linux-386"
-    i386.sha256 = "7bb4715606f66c6a1f42af53a1d9b61b684d8ab92258b423852b1d1b66487166"
     amd64.url = "https://github.com/go-gitea/gitea/releases/download/v1.22.3/gitea-1.22.3-linux-amd64"
     amd64.sha256 = "a720ff937912a6eb6c0cacf6ebcdd774deed5197cd945ecc34f5744cb5c517e8"
 
     autoupdate.strategy = "latest_github_release"
     autoupdate.asset.armhf = "^gitea-.*-linux-arm-6$"
     autoupdate.asset.arm64 = "^gitea-.*-linux-arm64$"
-    autoupdate.asset.i386 = "^gitea-.*-linux-386$"
     autoupdate.asset.amd64 = "^gitea-.*-linux-amd64$"
 
     [resources.system_user]


### PR DESCRIPTION
## Problem

- [1.22.4](https://github.com/go-gitea/gitea/releases/tag/v1.22.4) doesn't ship i386 artifact.

## Solution

- Remove from supported?

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
