### PR TITLE
Upgrade to v1.23.6

### DIFF
--- a/ALL_README.md
+++ b/ALL_README.md
@@ -1,6 +1,8 @@
 # All available README files by language
 
 - [Read the README in English](README.md)
+- [Llegir el README en català](README_ca.md)
+- [Die README in Deutsch lesen](README_de.md)
 - [Lea el README en español](README_es.md)
 - [Irakurri README euskaraz](README_eu.md)
 - [Lire le README en français](README_fr.md)

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ It shall NOT be edited by hand.
 Gitea is a fork of Gogs a self-hosted Git service written in Go. Alternative to GitHub.
 
 
-**Shipped version:** 1.23.5~ynh1
+**Shipped version:** 1.23.6~ynh1
 
 ## Screenshots
 

--- a/README_ca.md
+++ b/README_ca.md
@@ -1,0 +1,50 @@
+<!--
+N.B.: Aquest README ha estat generat automàticament per <https://github.com/YunoHost/apps/tree/master/tools/readme_generator>
+NO s'ha de modificar manualment.
+-->
+
+# Gitea per YunoHost
+
+[![Nivell d'integració](https://apps.yunohost.org/badge/integration/gitea)](https://ci-apps.yunohost.org/ci/apps/gitea/)
+![Estat de funcionament](https://apps.yunohost.org/badge/state/gitea)
+![Estat de manteniment](https://apps.yunohost.org/badge/maintained/gitea)
+
+[![Instal·la Gitea amb YunoHosth](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=gitea)
+
+*[Llegeix aquest README en altres idiomes.](./ALL_README.md)*
+
+> *Aquest paquet et permet instal·lar Gitea de forma ràpida i senzilla en un servidor YunoHost.*  
+> *Si no tens YunoHost, consulta [la guia](https://yunohost.org/install) per saber com instal·lar-lo.*
+
+## Visió general
+
+Gitea is a fork of Gogs a self-hosted Git service written in Go. Alternative to GitHub.
+
+
+**Versió inclosa:** 1.23.6~ynh1
+
+## Captures de pantalla
+
+![Captures de pantalla de Gitea](./doc/screenshots/screenshot.png)
+
+## Documentació i recursos
+
+- Lloc web oficial de l'aplicació: <https://gitea.io/>
+- Documentació oficial per l'administrador: <https://docs.gitea.io/>
+- Repositori oficial del codi de l'aplicació: <https://github.com/go-gitea/gitea>
+- Botiga YunoHost: <https://apps.yunohost.org/app/gitea>
+- Reportar un error: <https://github.com/YunoHost-Apps/gitea_ynh/issues>
+
+## Informació per a desenvolupadors
+
+Envieu les pull request a la [branca `testing`](https://github.com/YunoHost-Apps/gitea_ynh/tree/testing).
+
+Per provar la branca `testing`, procedir com descrit a continuació:
+
+```bash
+sudo yunohost app install https://github.com/YunoHost-Apps/gitea_ynh/tree/testing --debug
+o
+sudo yunohost app upgrade gitea -u https://github.com/YunoHost-Apps/gitea_ynh/tree/testing --debug
+```
+
+**Més informació sobre l'empaquetatge d'aplicacions:** <https://yunohost.org/packaging_apps>

--- a/README_de.md
+++ b/README_de.md
@@ -1,0 +1,50 @@
+<!--
+N.B.: Diese README wurde automatisch von <https://github.com/YunoHost/apps/tree/master/tools/readme_generator> generiert.
+Sie darf NICHT von Hand bearbeitet werden.
+-->
+
+# Gitea für YunoHost
+
+[![Integrations-Level](https://apps.yunohost.org/badge/integration/gitea)](https://ci-apps.yunohost.org/ci/apps/gitea/)
+![Funktionsstatus](https://apps.yunohost.org/badge/state/gitea)
+![Wartungsstatus](https://apps.yunohost.org/badge/maintained/gitea)
+
+[![Gitea mit YunoHost installieren](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=gitea)
+
+*[Dieses README in anderen Sprachen lesen.](./ALL_README.md)*
+
+> *Mit diesem Paket können Sie Gitea schnell und einfach auf einem YunoHost-Server installieren.*  
+> *Wenn Sie YunoHost nicht haben, lesen Sie bitte [die Anleitung](https://yunohost.org/install), um zu erfahren, wie Sie es installieren.*
+
+## Übersicht
+
+Gitea is a fork of Gogs a self-hosted Git service written in Go. Alternative to GitHub.
+
+
+**Ausgelieferte Version:** 1.23.6~ynh1
+
+## Bildschirmfotos
+
+![Bildschirmfotos von Gitea](./doc/screenshots/screenshot.png)
+
+## Dokumentation und Ressourcen
+
+- Offizielle Website der App: <https://gitea.io/>
+- Offizielle Verwaltungsdokumentation: <https://docs.gitea.io/>
+- Upstream App Repository: <https://github.com/go-gitea/gitea>
+- YunoHost-Shop: <https://apps.yunohost.org/app/gitea>
+- Einen Fehler melden: <https://github.com/YunoHost-Apps/gitea_ynh/issues>
+
+## Entwicklerinformationen
+
+Bitte senden Sie Ihren Pull-Request an den [`testing` branch](https://github.com/YunoHost-Apps/gitea_ynh/tree/testing).
+
+Um den `testing` Branch auszuprobieren, gehen Sie bitte wie folgt vor:
+
+```bash
+sudo yunohost app install https://github.com/YunoHost-Apps/gitea_ynh/tree/testing --debug
+oder
+sudo yunohost app upgrade gitea -u https://github.com/YunoHost-Apps/gitea_ynh/tree/testing --debug
+```
+
+**Weitere Informationen zur App-Paketierung:** <https://yunohost.org/packaging_apps>

--- a/README_es.md
+++ b/README_es.md
@@ -3,7 +3,7 @@ Este archivo README esta generado automaticamente<https://github.com/YunoHost/ap
 No se debe editar a mano.
 -->
 
-# Gitea para Yunohost
+# Gitea para YunoHost
 
 [![Nivel de integración](https://apps.yunohost.org/badge/integration/gitea)](https://ci-apps.yunohost.org/ci/apps/gitea/)
 ![Estado funcional](https://apps.yunohost.org/badge/state/gitea)
@@ -21,7 +21,7 @@ No se debe editar a mano.
 Gitea is a fork of Gogs a self-hosted Git service written in Go. Alternative to GitHub.
 
 
-**Versión actual:** 1.23.5~ynh1
+**Versión actual:** 1.23.6~ynh1
 
 ## Capturas
 

--- a/README_eu.md
+++ b/README_eu.md
@@ -21,7 +21,7 @@ EZ editatu eskuz.
 Gitea is a fork of Gogs a self-hosted Git service written in Go. Alternative to GitHub.
 
 
-**Paketatutako bertsioa:** 1.23.5~ynh1
+**Paketatutako bertsioa:** 1.23.6~ynh1
 
 ## Pantaila-argazkiak
 
@@ -39,7 +39,7 @@ Gitea is a fork of Gogs a self-hosted Git service written in Go. Alternative to 
 
 Bidali `pull request`a [`testing` abarrera](https://github.com/YunoHost-Apps/gitea_ynh/tree/testing).
 
-`testing` abarra probatzeko, ondorengoa egin:
+`testing` abarra probatzeko, honakoa egin:
 
 ```bash
 sudo yunohost app install https://github.com/YunoHost-Apps/gitea_ynh/tree/testing --debug

--- a/README_fr.md
+++ b/README_fr.md
@@ -21,7 +21,7 @@ Il NE doit PAS être modifié à la main.
 Gitea is a fork of Gogs a self-hosted Git service written in Go. Alternative to GitHub.
 
 
-**Version incluse :** 1.23.5~ynh1
+**Version incluse :** 1.23.6~ynh1
 
 ## Captures d’écran
 

--- a/README_gl.md
+++ b/README_gl.md
@@ -21,7 +21,7 @@ NON debe editarse manualmente.
 Gitea is a fork of Gogs a self-hosted Git service written in Go. Alternative to GitHub.
 
 
-**Versión proporcionada:** 1.23.5~ynh1
+**Versión proporcionada:** 1.23.6~ynh1
 
 ## Capturas de pantalla
 

--- a/README_id.md
+++ b/README_id.md
@@ -21,7 +21,7 @@ Ini TIDAK boleh diedit dengan tangan.
 Gitea is a fork of Gogs a self-hosted Git service written in Go. Alternative to GitHub.
 
 
-**Versi terkirim:** 1.23.5~ynh1
+**Versi terkirim:** 1.23.6~ynh1
 
 ## Tangkapan Layar
 

--- a/README_nl.md
+++ b/README_nl.md
@@ -21,7 +21,7 @@ Hij mag NIET handmatig aangepast worden.
 Gitea is a fork of Gogs a self-hosted Git service written in Go. Alternative to GitHub.
 
 
-**Geleverde versie:** 1.23.5~ynh1
+**Geleverde versie:** 1.23.6~ynh1
 
 ## Schermafdrukken
 

--- a/README_pl.md
+++ b/README_pl.md
@@ -21,7 +21,7 @@ Nie powinno być ono edytowane ręcznie.
 Gitea is a fork of Gogs a self-hosted Git service written in Go. Alternative to GitHub.
 
 
-**Dostarczona wersja:** 1.23.5~ynh1
+**Dostarczona wersja:** 1.23.6~ynh1
 
 ## Zrzuty ekranu
 

--- a/README_ru.md
+++ b/README_ru.md
@@ -21,7 +21,7 @@
 Gitea is a fork of Gogs a self-hosted Git service written in Go. Alternative to GitHub.
 
 
-**Поставляемая версия:** 1.23.5~ynh1
+**Поставляемая версия:** 1.23.6~ynh1
 
 ## Снимки экрана
 

--- a/README_zh_Hans.md
+++ b/README_zh_Hans.md
@@ -21,7 +21,7 @@
 Gitea is a fork of Gogs a self-hosted Git service written in Go. Alternative to GitHub.
 
 
-**分发版本：** 1.23.5~ynh1
+**分发版本：** 1.23.6~ynh1
 
 ## 截图
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "Gitea"
 description.en = "Lightweight Git forge"
 description.fr = "Forge Git légère"
 
-version = "1.23.5~ynh1"
+version = "1.23.6~ynh1"
 
 maintainers = ["Josué Tille"]
 # previous_maintainers = [
@@ -68,14 +68,14 @@ ram.runtime = "100M"
     extract = false
     rename = "gitea"
 
-    armhf.url = "https://github.com/go-gitea/gitea/releases/download/v1.23.5/gitea-1.23.5-linux-arm-6"
-    armhf.sha256 = "9be460d098dd5e3063c035876a068e2706498cd54bf6686ad170dc63dcfd60ca"
-    arm64.url = "https://github.com/go-gitea/gitea/releases/download/v1.23.5/gitea-1.23.5-linux-arm64"
-    arm64.sha256 = "9872f2fdf7e1187304bd69d0d0771350b4f1be98179f917fb60273e5b070a570"
-    i386.url = "https://github.com/go-gitea/gitea/releases/download/v1.23.5/gitea-1.23.5-linux-386"
-    i386.sha256 = "2d28f85f969d6e8fef9fb4e4d03c174942a144512faf4ad8d0a0cceed219ae5b"
-    amd64.url = "https://github.com/go-gitea/gitea/releases/download/v1.23.5/gitea-1.23.5-linux-amd64"
-    amd64.sha256 = "60773eabdacaf2d787200649b6756a66d96cb581ae45df9d492f952f97926915"
+    armhf.url = "https://github.com/go-gitea/gitea/releases/download/v1.23.6/gitea-1.23.6-linux-arm-6"
+    armhf.sha256 = "638734e1c5a58e9687f1188af73f9d5de265b98d1c28259472dcf41260cf6f4f"
+    arm64.url = "https://github.com/go-gitea/gitea/releases/download/v1.23.6/gitea-1.23.6-linux-arm64"
+    arm64.sha256 = "655a79014575517c844f8f95208d645908addea8b1cfd679606ee898ca943477"
+    i386.url = "https://github.com/go-gitea/gitea/releases/download/v1.23.6/gitea-1.23.6-linux-386"
+    i386.sha256 = "63ebbaddd258474be76d01fab9ad630e01ce45d4b47199582607eeae073b2323"
+    amd64.url = "https://github.com/go-gitea/gitea/releases/download/v1.23.6/gitea-1.23.6-linux-amd64"
+    amd64.sha256 = "fcb76127fec7ba9fba10bfe11d81cdc01888aacb588fc4f29b124bf2ffba883e"
 
     autoupdate.strategy = "latest_github_release"
     autoupdate.asset.armhf = "^gitea-.*-linux-arm-6$"


### PR DESCRIPTION
Upgrade sources
- `main` v1.23.6: https://github.com/go-gitea/gitea/releases/tag/v1.23.6

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
