### PR TITLE
Update ADMIN.md

### DIFF
--- a/doc/ADMIN.md
+++ b/doc/ADMIN.md
@@ -99,7 +99,7 @@ yunohost backup create --app __APP__
 - Restart Gitea service:
 
 ```bash
-systemctl stop __APP__.service
+systemctl start __APP__.service
 ```
 
 ## Remove


### PR DESCRIPTION
Fixed error: a "stop" instruction instead of "start" when restarting `gitea.service` after upgrade is applied.

## Problem

- Typo in the backup instructions: a "stop" instruction is applied instead of a "start" instruction after upgrade is performed.

## Solution

- *Change "stop" for "start"*

## PR Status

- [X] Code finished and ready to be reviewed/tested
- [X] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
