### PR TITLE
Upgrade to v1.23.7

### DIFF
--- a/doc/ADMIN.md
+++ b/doc/ADMIN.md
@@ -99,7 +99,7 @@ yunohost backup create --app __APP__
 - Restart Gitea service:
 
 ```bash
-systemctl stop __APP__.service
+systemctl start __APP__.service
 ```
 
 ## Remove

--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "Gitea"
 description.en = "Lightweight Git forge"
 description.fr = "Forge Git légère"
 
-version = "1.23.6~ynh1"
+version = "1.23.7~ynh1"
 
 maintainers = ["Josué Tille"]
 # previous_maintainers = [
@@ -68,14 +68,14 @@ ram.runtime = "100M"
     extract = false
     rename = "gitea"
 
-    armhf.url = "https://github.com/go-gitea/gitea/releases/download/v1.23.6/gitea-1.23.6-linux-arm-6"
-    armhf.sha256 = "638734e1c5a58e9687f1188af73f9d5de265b98d1c28259472dcf41260cf6f4f"
-    arm64.url = "https://github.com/go-gitea/gitea/releases/download/v1.23.6/gitea-1.23.6-linux-arm64"
-    arm64.sha256 = "655a79014575517c844f8f95208d645908addea8b1cfd679606ee898ca943477"
-    i386.url = "https://github.com/go-gitea/gitea/releases/download/v1.23.6/gitea-1.23.6-linux-386"
-    i386.sha256 = "63ebbaddd258474be76d01fab9ad630e01ce45d4b47199582607eeae073b2323"
-    amd64.url = "https://github.com/go-gitea/gitea/releases/download/v1.23.6/gitea-1.23.6-linux-amd64"
-    amd64.sha256 = "fcb76127fec7ba9fba10bfe11d81cdc01888aacb588fc4f29b124bf2ffba883e"
+    armhf.url = "https://github.com/go-gitea/gitea/releases/download/v1.23.7/gitea-1.23.7-linux-arm-6"
+    armhf.sha256 = "c56914a08026cd4b595603da327cdd46740d5e58ee10158dcecc7940ac3e2bc7"
+    arm64.url = "https://github.com/go-gitea/gitea/releases/download/v1.23.7/gitea-1.23.7-linux-arm64"
+    arm64.sha256 = "eaaf65d888e06dd5fd72c6e01575eab1863aad186133dfc199d243b3bbc56e49"
+    i386.url = "https://github.com/go-gitea/gitea/releases/download/v1.23.7/gitea-1.23.7-linux-386"
+    i386.sha256 = "7b33713b338973ebb1d7ff7912142d012ab59e232504f30cd6654880d2a58575"
+    amd64.url = "https://github.com/go-gitea/gitea/releases/download/v1.23.7/gitea-1.23.7-linux-amd64"
+    amd64.sha256 = "3c0a7121ad1d9c525a92c68a7c040546553cd41e7464ce2fa811246b648c0a46"
 
     autoupdate.strategy = "latest_github_release"
     autoupdate.asset.armhf = "^gitea-.*-linux-arm-6$"


### PR DESCRIPTION
Upgrade sources
- `main` v1.23.7: https://github.com/go-gitea/gitea/releases/tag/v1.23.7

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
