### PR TITLE
restore: set permission to the logs folder

### DIFF
--- a/scripts/restore
+++ b/scripts/restore
@@ -36,7 +36,9 @@ yunohost service add "$app" --log="/var/log/$app/gitea.log"
 ynh_script_progression "Configuring fail2ban..."
 ynh_config_add_fail2ban --logpath="/var/log/$app/gitea.log" --failregex=".*Failed authentication attempt for .* from <HOST>"
 
-mkdir -p /var/log/"$app"
+mkdir -p "/var/log/$app"
+chown -R "$app:$app" "/var/log/$app"
+
 ynh_config_add_logrotate
 
 #=================================================


### PR DESCRIPTION
## Problem

See https://forum.yunohost.org/t/gitea-restore-backup-failed/39984/17

## Solution

This ensures to keep the good ownership for the logs directory. After the app is removed, the log directory could have been kept. But the user does not exist anymore, and the owner is referenced by a user ID. It could happen that the user ID has been assigned to another user in the meantime, and thus the log directory granted to that user.

So when the app is restored, the folder exists but it is not owned by the right user.

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
